### PR TITLE
Fix/antlr/uptodate

### DIFF
--- a/antlr/tsl.expr
+++ b/antlr/tsl.expr
@@ -198,3 +198,41 @@ select('foo').add(1).timemodulo(100, "mod")
 mySelect.renameLabelValue("dc", "lg.*", "new-dc")
 
 add(mySelect.add(1), select('foo').add(1).timemodulo(100, "mod"))
+
+select('foo').abs()
+select('foo').resets()
+
+select('foo').finite()
+
+select('foo').keepLastValues()
+select('foo').keepLastValues(10)
+select('foo').keepFirstValues(10)
+select('foo').keepFirstValues()
+
+select('foo').timesplit(now, 42, 'test')
+select('foo').timesplit(1h, 4, 'test')
+select('foo').timesplit(20000000, 1, 'test')
+select('foo').timemodulo(42, "quotient")
+select('foo').timeclip(now, 200000)
+select('foo').timeclip(1535641320000000, 2m)
+select('foo').timeclip("2018-04-22T00:57:00-05:00", "2018-04-22T01:00:00-05:00")
+
+select('foo').quantize("quantile", 0.1)
+select('foo').quantize("quantile", 0.1, 2m)
+select('foo').quantize("quantile",[ 0, 10 ], 2m)
+select('foo').quantize("quantile",[ 0, 10 ])
+
+select('foo').tolong()
+select('foo').toboolean()
+select('foo').todouble()
+select('foo').tostring()
+
+select("sys.cpu.nice")
+  .from(1346846400000000,1346847000006000)
+  .sampleBy(span=1m, aggregator="mean", fill=fill(0), relative=false)
+
+
+create(series("name"), series("name"))
+
+create(series("test").setLabels(["l0=42","l1=42"]).setValues(now, [ -5m, 2], [0, 1]).setValues(now,[ 2m, 3]), series("test2").setLabels(["l0=42","l1=42"]).setValues(now, [-5m, 2], [0, 1]))
+    .sampleBy(30s, max)

--- a/antlr/tslTokens.g4
+++ b/antlr/tslTokens.g4
@@ -2,10 +2,15 @@ lexer grammar tslTokens; // note "TSL tokens"
 
 // TSL native types and tokens
 DURATIONVAL: INT_LIT ([wdhms]|'ms'|'us'|'ns'|'ps')
+    | '-' INT_LIT ([wdhms]|'ms'|'us'|'ns'|'ps')
     ;
+
+
 
 NUMBER: INT_LIT 
     | FLOAT_LIT
+    | '-' INT_LIT
+    | '-' FLOAT_LIT
     ;
 
 STRING: RAW_STRING_LIT
@@ -38,15 +43,18 @@ BOTTOMNBY:         'bottomNBy';
 CEIL:              'ceil';
 CONNECT:           'connect';
 COUNT:             'count';
+CREATE:            'create';
 CUMULATIVE:        'cumulative';
 CUMULATIVESUM:     'cumulativeSum';
 DAY:               'day';
 DELTA:             'delta';
 DIVSERIES:         'div';
 EQUAL:             'equal';
+FILL:              'fill';
 FILTERBYLABELS:    'filterByLabels';
 FILTERBYNAME:      'filterByName';
 FILTERBYLASTVALUE: 'filterByLastValue';
+FINITE:            'finite';
 FIRST:             'first';
 FLOOR:             'floor';
 FROM:              'from';
@@ -60,6 +68,8 @@ GROUPWITHOUT:      'groupWithout';
 HOUR:              'hour';
 IGNORING:          'ignoring';
 JOIN:              'join';
+KEEPFIRSTVALUES:   'keepFirstValues';
+KEEPLASTVALUES:    'keepLastValues';
 LAST:              'last';
 LABELS:            'labels';
 LESSOREQUAL:       'lessOrEqual';
@@ -80,12 +90,14 @@ MONTH:             'month';
 MULSERIES:         'mul';
 NEGMASK:           'negmask';
 NOTEQUAL:          'notEqual';
+NOW:               'now';
 NAMES:             'names';
 ON:                'on';
 ORL:               'or';
 PERCENTILE:        'percentile';
 PROM:              'prom';
 PROMETHEUS:        'prometheus';
+QUANTIZE:          'quantize';
 RATE:              'rate';
 REMOVELABELS:      'removeLabels';
 REMOVE:            'remove';
@@ -99,6 +111,9 @@ SAMPLE:            'sample';
 SAMPLEBY:          'sampleBy';
 SELECT:            'select';
 SELECTORS:         'selectors';
+SERIES:            'series';
+SETLABELS:         'setLabels';
+SETVALUES:         'setValues';
 SHIFT:             'shift';
 SHRINK:            'shrink';
 SORT:              'sort';
@@ -111,8 +126,12 @@ STDVAR:            'stdvar';
 STORE:             'store';
 SUBSERIES:         'sub';
 SUM:               'sum';
+TOBOOLEAN:         'toboolean';
+TODOUBLE:          'todouble';
+TOLONG:            'tolong';
 TOPN:              'topN';
 TOPNBY:            'topNBy';
+TOSTRING:          'tostring';
 TIMECLIP:          'timeclip';
 TIMEMODULO:        'timemodulo';
 TIMESTAMP:         'timestamp';

--- a/spec/doc.md
+++ b/spec/doc.md
@@ -735,12 +735,14 @@ The **series** method is used to create a Time Series, only in Warp 10 for now, 
 
 The **setValues** takes n parameter, the first one (optional) is the base Timestamp of the values (by default zero). Then the other are a two elements array composed of a timestamp (that would be add to the base one) and the value to set. Use example: _.setValues([0, 1], [100, 2])._
 
-At the end of the create statement, all other Time Series method can be apply on.
+The **setLabels** takes a single parameter: a labels string list where the key and values are split per the equals symbol.
+
+At the end of the create statement, all other Time Series set methods can be apply on.
 
 A more complex but valid tsl statement to create 2 Time Series would be:
 
 ```tsl
-create(series("test").setLabels(["l0=42","l1=42"]).setValues("now", [-5m, 2], [0, 1]).setValues("now",[2m, 3]),series("test2").setLabels(["l0=42","l1=42"]).setValues("now", [-5m, 2], [0, 1]))
+create(series("test").setLabels(["l0=42","l1=42"]).setValues("now", [-5m, 2], [0, 1]).setValues("now",[2m, 3]),series("test2").setLabels(["l0=42","l1=42"]).setValues(now, [-5m, 2], [0, 1]))
 	 .sampleBy(30s, max)
 ``` 
 

--- a/spec/doc.md
+++ b/spec/doc.md
@@ -429,7 +429,7 @@ The following TSL methods can be used to apply arithmetic operators on metrics:
 * The **logN** operator. Compute values logN of the **number parameter**, example: _.logN(2)_
 * The **rate** operator. Compute a **rate** (by default per second when no parameter are sets) or on a specify duration, example: _.rate()_, _.rate(1m)_
 * The **sqrt** operator. Compute values **square root**, example: _.sqrt()_
-* The **quantize** operator. Compute the amount of **values** inside a **step** on the complete query range or per parameter duration. This generate a single metric per step, based on the label key specified as first parameter. The second parameter corresponds to the step value: it can be a single number or integer value, or a fix step set modelised as a number or integer list. The last optional parameter for the quantize method is the quantize duration. This method can be useful to compute histograms, use example: _.quantize("quantile", [ 0, 10 ], 2m))_, _.quantize("quantile", 0.1))_
+* The **quantize** operator. Compute the amount of **values** inside a **step** on the complete query range or per parameter duration. This generate a single metric per step, based on the label key specified as first parameter. The second parameter corresponds to the step value: it can be a single number or integer value, or a fix step set modelised as a number or integer list. The last optional parameter for the quantize method is the quantize duration. This method can be useful to compute histograms, use example: _.quantize("quantile", [ 0, 10 ], 2m)_, _.quantize("quantile", 0.1)_
 
 > The **logN** operator is not available on **Prometheus**.
 


### PR DESCRIPTION
fix #27 
Add in ANTLR the missing:
 - Simple functions (finite, keepLastValues, keepFirstValues, toboolean, todouble, tolong, tostring)
 - The quantize function
 - The `now` keyword
 - The fill (fill by a value) method as sampleBy fill parameter
 - The Create a time series set methods: create, series, setLabels and setValues