### PR TITLE
feat(wasm): Allow to run tls interpreter for the web by compiling in wasm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ DATE			:= $(shell TZ=UTC date -u '+%Y-%m-%dT%H:%M:%SZ UTC')
 DFLAGS		:= -race
 CFLAGS		:= -X 'github.com/ovh/tsl/cmd.githash=$(GITHASH)' -X 'github.com/ovh/tsl/cmd.date=$(DATE)' -X 'github.com/ovh/tsl/cmd.gitbranch=$(GITBRANCH)'
 CROSS			:= GOOS=linux GOARCH=amd64
+WASMFLAGS	:= GOOS=js GOARCH=wasm
+WASMEXEC	:= tsl.wasm
 
 FORMAT_PATHS	:= ./cmd/ ./middlewares/ ./tsl tsl.go
 LINT_PATHS		:= ./ ./cmd/... ./middlewares/... ./tsl/...
@@ -32,6 +34,7 @@ dep:
 clean:
 	rm -rf build
 	rm -rf vendor
+	rm -f *.wasm
 
 .PHONY: lint
 lint:
@@ -53,6 +56,10 @@ dev: format lint build
 .PHONY: build
 build: tsl.go $$(call rwildcard, ./cmd, *.go) $$(call rwildcard, ./core, *.go) $$(call rwildcard, ./tsl, *.go) $$(call rwildcard, ./middlewares, *.go)
 	$(CC) $(DFLAGS) -ldflags "$(CFLAGS)" -o $(BUILD_DIR)/tsl tsl.go
+
+.PHONY: wasm
+wasm:
+	$(WASMFLAGS) $(CC) -o $(WASMEXEC) wasm.go
 
 .PHONY: release
 release: tsl.go $$(call rwildcard, ./cmd, *.go) $$(call rwildcard, ./core, *.go) $$(call rwildcard, ./tsl, *.go) $$(call rwildcard, ./middlewares, *.go)

--- a/README.md
+++ b/README.md
@@ -129,6 +129,27 @@ Flags:
 Use "tsl [command] --help" for more information about a command.
 ```
 
+## Use TSL with WebAssembly
+
+NOTE: A Go 1.11 version at least is needed.
+
+You can run the TSL to WarpScript interpreter in a WebAssembly program.
+The `tsl.wasm` file export the method `tslToWarpScript` callable from JavaScript running in a browser or NodeJS.
+
+To compile the `tsl` package for the web:
+
+`$ make wasm`
+
+As example, you can call the `tslToWarpScript` from a JavaScript program like that:
+
+```javascript
+tslToWarpScript("select(\"sys.cpu.nice\").where(\"host=web01\").from(1346846400000,to=1346847000005)", "", false, (err, res) => {
+	console.log(res) // Output the tsl query in a WarpScript syntax
+})
+```
+
+To integrate the `tsl.wasm` file in your program, you should follow the Golang WebAssembly [wiki](https://github.com/golang/go/wiki/WebAssembly).
+
 ## Licensing
 
 See the LICENSE file.

--- a/wasm.go
+++ b/wasm.go
@@ -1,0 +1,71 @@
+package main
+
+//
+// This is the main use to run the TLS interpreter with WASM.
+// The method tslToWarpScript is exported to the JavaScript.
+//
+
+import (
+	"./tsl"
+	"bytes"
+	"strings"
+	"syscall/js"
+)
+
+// tslToWarpScriptWasm method to generate WarpScript from TSL statements in WASM and return result with a callback
+func tslToWarpScriptWasm(this js.Value, inputs []js.Value) interface{} {
+	tslQuery := inputs[0].String()
+	defaulToken := inputs[1].String()
+	allowAuthenticate := inputs[2].Bool()
+	callback := inputs[len(inputs)-1:][0]
+
+	// Get query parsing result
+	parser, err := tsl.NewParser(strings.NewReader(tslQuery), "warp", defaulToken, 0, "", "")
+	if err != nil {
+		callback.Invoke(err.Error(), js.Null())
+		return nil
+	}
+
+	query, err := parser.Parse()
+	if err != nil {
+		callback.Invoke(err.Error(), js.Null())
+		return nil
+	}
+
+	// Output query buffer
+	var buffer bytes.Buffer
+
+	instructions := []tsl.Instruction{}
+
+	for _, instruction := range query.Statements {
+		instructions = append(instructions, *instruction)
+	}
+
+	protoParser := tsl.ProtoParser{Name: "warp 10", LineStart: 0}
+	warpscript, err := protoParser.GenerateWarpScript(instructions, allowAuthenticate)
+	if err != nil {
+		callback.Invoke(err.Error(), js.Null())
+		return nil
+	}
+
+	buffer.WriteString(warpscript)
+	buffer.WriteString("\n")
+	// By default return an empty array
+	if buffer.String() == "" {
+		buffer.WriteString("[]")
+	}
+
+	callback.Invoke(js.Null(), buffer.String())
+
+	return nil
+}
+
+func main() {
+	// Go takes a different approach on WASM compared with Rust/C++.
+	// Go treats this as an application, meaning that you start a Go runtime, it runs, then exits and you can’t interact with it.
+	// If we want to be able to call stuff, but the runtime want to shut down we have to use this channel tricks in order to call
+	// tslTowarpscript method as many times as we like.
+	c := make(chan bool)
+	js.Global().Set("tslToWarpScript", js.FuncOf(tslToWarpScriptWasm))
+	<-c
+}


### PR DESCRIPTION
This PR adds a new target of compilation: `WebAssembly` with the `wasm` format.
The idea is to allow a user to run the TSL interpreter in a NodeJS, browser Javascript program.
That could be used in Grafana script where for now, only WarpScript can be used.

The `tsl.wasm` export the method `tslToWarpScript` to the JavaScript. That allows the user to translate TSL query to WarpScript in a Javascript program. For a technical constraint on Go + wasm, we have to return results by using a callback. 

**example:**
```javascript
tslToWarpScript("select(\"sys.cpu.nice\").where(\"host=web01\").from(1346846400000,to=1346847000005)", "", false, (err, res) => {
	console.log(res) // Output the tsl query in a WarpScript syntax
})
```

I needed a `main package` to create a valid wasm obj file. So I had to create in the root folder a wasm.go in a `package main` which a `main`. I have not been able to compile the project with this file in the `tsl/` folder. Maybe you know a way to do this :smile:?