### PR TITLE
WIP: npm package to contain the wasm.tsl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: go
+
+env:
+- WASMEXEC=build/tsl.wasm  
+
+go:
+- 1.11.x
+
+before_script:
+- mkdir build
+
+script:
+- make wasm
+
+# create npm package
+after_success:
+- cp wasm/index.js build
+- cp wasm/package.json build
+- cp $(go env GOROOT)/misc/wasm/wasm_exec.js build/wasm_exec.js
+# npm publish
+- ls build

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,16 @@ go:
 
 go_import_path: github.com/ovh/tsl
 
-before_script:
-- mkdir build
+install:
+# install nodejs to create the package
+- curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+- sudo apt-get install -y nodejs
+# install godep
 - go get -u github.com/golang/dep/cmd/dep
 - make dep
+
+before_script:
+- mkdir build
 
 script:
 - make wasm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 env:
-- WASMEXEC=build/tsl.wasm  
+- WASMEXEC=build/tsl.wasm
 
 go:
 - 1.12.x
@@ -24,8 +24,8 @@ script:
 
 # create npm package
 after_success:
+- cp tsl.wasm build
 - cp wasm/index.js build
 - cp wasm/package.json build
 - cp $(go env GOROOT)/misc/wasm/wasm_exec.js build/wasm_exec.js
-# npm publish
-- ls build
+# TODO: npm publish build dir steps

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,7 @@ after_success:
 - cp tsl.wasm build
 - cp wasm/index.js build
 - cp wasm/package.json build
+-  sed -i "s|<%version%>|$(build/tsl version -r)|g" build/package.json
+
 - cp $(go env GOROOT)/misc/wasm/wasm_exec.js build/wasm_exec.js
 # TODO: npm publish build dir steps

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ go_import_path: github.com/ovh/tsl
 
 before_script:
 - mkdir build
+- go get -u github.com/golang/dep/cmd/dep
+- make dep
 
 script:
 - make wasm

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
 - WASMEXEC=build/tsl.wasm  
 
 go:
-- 1.11.x
+- 1.12.x
 
 go_import_path: github.com/ovh/tsl
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ env:
 go:
 - 1.11.x
 
+go_import_path: github.com/ovh/tsl
+
 before_script:
 - mkdir build
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -12,9 +12,11 @@ var (
 	githash   = "HEAD"
 	gitbranch = "master"
 	date      = "1970-01-01T00:00:00Z UTC"
+	rawPrint  = false
 )
 
 func init() {
+	versionCmd.PersistentFlags().BoolVarP(&rawPrint, "raw", "r", false, "print only the version number")
 	RootCmd.AddCommand(versionCmd)
 }
 
@@ -22,8 +24,12 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("tsl server version %s %s/%s\n", version, gitbranch, githash)
-		fmt.Printf("tsl server build date %s\n", date)
-		fmt.Printf("go version %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		if rawPrint {
+			fmt.Print(version)
+		} else {
+			fmt.Printf("tsl server version %s %s/%s\n", version, gitbranch, githash)
+			fmt.Printf("tsl server build date %s\n", date)
+			fmt.Printf("go version %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		}
 	},
 }

--- a/wasm/index.js
+++ b/wasm/index.js
@@ -1,0 +1,9 @@
+import go from "./wasm_exec.js"
+
+function loadTslWasm(wasmFilePath, callback) {
+    WebAssembly.instantiateStreaming(fetch(wasmFilePath), go.importObject).then(callback);
+}
+
+export default {
+    loadTslWasm,
+}

--- a/wasm/index.js
+++ b/wasm/index.js
@@ -1,9 +1,1 @@
-import go from "./wasm_exec.js"
-
-function loadTslWasm(wasmFilePath, callback) {
-    WebAssembly.instantiateStreaming(fetch(wasmFilePath), go.importObject).then(callback);
-}
-
-export default {
-    loadTslWasm,
-}
+// npm package require a main js file

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "tsl",
+  "version": "0.0.1",
+  "description": "Library to generate WarpScript or a PromQl script based on a TSL query",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "tsl",
-  "version": "0.0.1",
+  "name": "tsl-wasm",
+  "version": "<%version%>",
   "description": "Library to generate WarpScript or a PromQl script based on a TSL query",
   "main": "index.js",
   "scripts": {

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -7,5 +7,5 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC"
+  "license": "Modified 3-Clause BSD"
 }


### PR DESCRIPTION
work for #46 

This PR adds the first works to create an NPM package for the `tsl.wasm`. The package also contains the `$(go env GOROOT)/misc/wasm/wasm_exec.js ` needed to run a go wasm with wasm vm. To automate the packaging of `tsl.wasm` I created a `.travis.yml`.

What we need to continue:
- An npm account to host the tsl package
- A travisCI account to run the CI that create the package
- Add metadata (license, ...) in the `package.json`.
- A README in the npm package to be used as a doc.
- a review of course